### PR TITLE
fix carousel responsive images

### DIFF
--- a/docs/_layouts/home.html
+++ b/docs/_layouts/home.html
@@ -18,7 +18,26 @@ layout: default
     <section id="mobile-carousel">
       {% include carousel.html height="200" unit="%" duration="7" number="1" %}
     </section>
-    <section id="desktop-images"></section>
+    <section id="tablet-images">
+      <img src="assets/images/connect.png" alt="Rosie connect image">
+      <img src="assets/images/sdoh.png" alt="Rosie survey image">
+      <img src="assets/images/carePlan.png" alt="Rosie care plan image">
+      <img src="assets/images/bpView.png" alt="Rosie blood pressure image">
+      <img src="assets/images/addBP.png" alt="Rosie edit blood pressure image">
+      <img src="assets/images/healthGoals.png" alt="Rosie care plan image">
+      <img src="assets/images/sharing.png" alt="Rosie sharing health data image">
+      <img src="assets/images/visits.png" alt="Rosie upcoming visits image">
+    </section>
+    <section id="desktop-images">
+      <img src="assets/images/connect.png" alt="Rosie connect image">
+      <img src="assets/images/sdoh.png" alt="Rosie survey image">
+      <img src="assets/images/carePlan.png" alt="Rosie care plan image">
+      <img src="assets/images/bpView.png" alt="Rosie blood pressure image">
+      <img src="assets/images/addBP.png" alt="Rosie edit blood pressure image">
+      <img src="assets/images/healthGoals.png" alt="Rosie care plan image">
+      <img src="assets/images/sharing.png" alt="Rosie sharing health data image">
+      <img src="assets/images/visits.png" alt="Rosie upcoming visits image">
+    </section>
   </div>
 </article>
 

--- a/docs/assets/css/main.scss
+++ b/docs/assets/css/main.scss
@@ -146,6 +146,52 @@ p {
     em {
         font-weight: bold;
     }
+    #tablet-images {
+        display: none;
+    }
+    #desktop-images {
+        display: none;
+    }
+    @media screen and (min-width: 900px) {
+        .wrapper {
+            max-width: 900px;
+        }
+        #mobile-carousel {
+            display: none;
+        }
+        #tablet-images {
+            margin: 20px auto;
+            display: grid;
+            height: auto;
+            width: 100%;
+            grid-template-columns: 1fr 1fr 1fr 1fr;
+            align-items: center;
+            img {
+                margin: 0 auto;
+                width: 200px;
+                height: auto;
+            }
+        }
+    }
+    @media screen and (min-width: 1535px) {
+        .wrapper {
+            max-width: 1535px;
+        }
+        #mobile-carousel {
+            display: none;
+        }
+        #tablet-images {
+            display: none;
+        }
+        #desktop-images {
+            margin: 20px;
+            display: block;
+            img {
+                width: 175px;
+                height: auto;
+            }
+        }
+    }
 }
 
 #four-elements {


### PR DESCRIPTION
Add responsive carousel images, changes at mobile (<900px), tablet (900-1535px), and desktop (>1535px) breakpoints.
- Add alt text for the images.